### PR TITLE
Fix volume persistence

### DIFF
--- a/packages/web/src/components/molecules/VolumeControl/VolumeControl.tsx
+++ b/packages/web/src/components/molecules/VolumeControl/VolumeControl.tsx
@@ -12,8 +12,10 @@ type VolumeControlProps = {
 
 const VOLUME_KEY = 'mw-volume';
 
-const updateVolume = (volume: number) =>
-  debounce(() => localStorage.setItem(VOLUME_KEY, volume.toString()), 1000);
+const updateVolume = debounce(
+  (volume: number) => localStorage.setItem(VOLUME_KEY, volume.toString()),
+  1000,
+);
 
 export const VolumeControl = ({ volume, onChange }: VolumeControlProps) => {
   // get volume from local storage and sync with redux on mount


### PR DESCRIPTION
The volume value was not being persisted correctly due to an incorrect debounce definition.