### PR TITLE
Create a new Recent route, moving page measurement and track controls into a route layout

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,35 +1,17 @@
 import { BrowserRouter, Route, Routes } from 'react-router';
 
+import { PlayerLayout } from '~/components/templates/PlayerLayout/PlayerLayout';
 import { Home } from '~/components/views/Home';
-
-// const router = createBrowserRouter([
-//   {
-//     path: '/',
-//     element: <Home />,
-//   },
-//   {
-//     path: '/login',
-//     element: <Login />,
-//   },
-//   {
-//     path: '/playlists',
-//     element: <Home />, // TODO: Create Playlists component
-//   },
-//   {
-//     path: '/recent',
-//     element: <Home />, // TODO: Create Recent component
-//   },
-// ]);
-
-// function App() {
-//   return <RouterProvider router={router} />;
-// }
+import { Recent } from '~/components/views/Recent';
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Home />} />
+        <Route element={<PlayerLayout />}>
+          <Route path="/" element={<Home />} />
+          <Route path="/recent" element={<Recent />} />
+        </Route>
       </Routes>
     </BrowserRouter>
   );

--- a/packages/web/src/components/atoms/FullHeightContainer/FullHeightContainer.tsx
+++ b/packages/web/src/components/atoms/FullHeightContainer/FullHeightContainer.tsx
@@ -1,0 +1,45 @@
+import clsx from 'clsx';
+import { createContext, PropsWithChildren, useContext } from 'react';
+
+import { useAvailableDimensions } from '~/hooks/useAvailableDimensions';
+
+export type FullHeightContainerContext = {
+  idToMeasure?: string;
+  height?: number;
+  refToMeasure?: ReturnType<typeof useAvailableDimensions>['refToMeasure'];
+};
+
+export const FullHeightContainerContext =
+  createContext<FullHeightContainerContext | null>({});
+
+export const FullHeightContainer = ({
+  children,
+  idToMeasure = 'library-container',
+  className,
+}: PropsWithChildren<{ idToMeasure?: string; className?: string }>) => {
+  const { refToMeasure, height } = useAvailableDimensions(idToMeasure);
+  return (
+    <div
+      className={clsx(className)}
+      tabIndex={0}
+      ref={refToMeasure}
+      style={{ height }}
+    >
+      <FullHeightContainerContext.Provider
+        value={{ idToMeasure, height, refToMeasure }}
+      >
+        {children}
+      </FullHeightContainerContext.Provider>
+    </div>
+  );
+};
+
+export const useFullHeightContainerContext = () => {
+  const context = useContext(FullHeightContainerContext);
+  if (!context) {
+    throw new Error(
+      'useFullHeightContainerContext must be used within a FullHeightContainer',
+    );
+  }
+  return context;
+};

--- a/packages/web/src/components/atoms/FullHeightContainer/index.tsx
+++ b/packages/web/src/components/atoms/FullHeightContainer/index.tsx
@@ -1,0 +1,1 @@
+export * from './FullHeightContainer';

--- a/packages/web/src/components/molecules/TrackList/TrackList.tsx
+++ b/packages/web/src/components/molecules/TrackList/TrackList.tsx
@@ -1,9 +1,9 @@
 import { EntityId } from '@reduxjs/toolkit';
-import React, { forwardRef, useRef, useEffect, useMemo } from 'react';
+import React, { forwardRef, useRef, useEffect } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { FixedSizeList } from 'react-window';
 
-import { useAvailableDimensions } from '~/hooks';
+import { FullHeightContainer } from '~/components/atoms/FullHeightContainer/FullHeightContainer';
 import { useTrackSelection } from '~/hooks/useTrackSelection';
 import { Track } from '~/types/library';
 
@@ -62,8 +62,6 @@ export const TrackList = ({
   const { selectedTracks, handleTrackSelection, clearSelection } =
     useTrackSelection(trackIDs);
   const listRef = useRef<FixedSizeList>(null);
-  const { refToMeasure: libraryRef, height } =
-    useAvailableDimensions(containerId);
 
   // Add effect to scroll to track when scrollToTrack changes
   useEffect(() => {
@@ -88,16 +86,14 @@ export const TrackList = ({
   return (
     <>
       <TrackListHeader />
-      <div
+      <FullHeightContainer
+        idToMeasure={containerId}
         className="border-t border-border relative bg-card transition-colors"
-        style={{ height }}
-        ref={libraryRef}
       >
         <div className="h-full">
           <ScrollIndicator
             currentTrack={currentTrack ?? null}
             trackIDs={trackIDs}
-            height={height ?? 0}
           />
           <AutoSizer>
             {({ width, height: innerHeight }) => (
@@ -139,7 +135,7 @@ export const TrackList = ({
             )}
           </AutoSizer>
         </div>
-      </div>
+      </FullHeightContainer>
       <SelectionToolbar
         selectedTracks={selectedTracks}
         onAddToPlaylist={handleAddToPlaylist}

--- a/packages/web/src/components/molecules/TrackList/components/ScrollIndicator.tsx
+++ b/packages/web/src/components/molecules/TrackList/components/ScrollIndicator.tsx
@@ -1,6 +1,7 @@
 import { EntityId } from '@reduxjs/toolkit';
 import React, { useMemo, CSSProperties } from 'react';
 
+import { useFullHeightContainerContext } from '~/components/atoms/FullHeightContainer/FullHeightContainer';
 import { Track } from '~/types/library';
 
 const MOBILE_BREAKPOINT = 640;
@@ -9,14 +10,13 @@ const SCROLLBAR_WIDTH = 12;
 type ScrollIndicatorProps = {
   currentTrack: Track | null;
   trackIDs: EntityId[];
-  height: number;
 };
 
 export function ScrollIndicator({
   currentTrack,
   trackIDs,
-  height,
 }: ScrollIndicatorProps) {
+  const { height } = useFullHeightContainerContext();
   const style = useMemo((): CSSProperties | null => {
     if (!currentTrack || !height) return null;
     const currentTrackIndex = trackIDs.findIndex(

--- a/packages/web/src/components/templates/PlayerLayout/PlayerLayout.tsx
+++ b/packages/web/src/components/templates/PlayerLayout/PlayerLayout.tsx
@@ -1,0 +1,31 @@
+import { useCallback, useState } from 'react';
+import { Outlet } from 'react-router';
+
+import { Controls } from '~/components/molecules/Controls';
+import { Nav } from '~/components/molecules/Nav';
+import { SearchHeader } from '~/components/molecules/SearchHeader';
+import { PageContainer } from '~/components/templates/PageContainer';
+import { PlayerProvider } from '~/context/PlayerContext';
+
+export const PlayerLayout = () => {
+  const [navOpen, setNavOpen] = useState(false);
+  const toggleNavOpen = useCallback(() => setNavOpen((o) => !o), [setNavOpen]);
+  return (
+    <PlayerProvider>
+      <PageContainer>
+        <Nav open={navOpen} toggleNav={toggleNavOpen} />
+        <div className="flex flex-col w-0 flex-1 overflow-hidden">
+          <SearchHeader onToggleNavigationOpen={toggleNavOpen} />
+          <main
+            className="flex-1 @container flex-col flex-nowrap relative z-0 overflow-hidden focus:outline-hidden"
+            tabIndex={0}
+            id="library-container"
+          >
+            <Outlet />
+            <Controls />
+          </main>
+        </div>
+      </PageContainer>
+    </PlayerProvider>
+  );
+};

--- a/packages/web/src/components/templates/PlayerLayout/index.tsx
+++ b/packages/web/src/components/templates/PlayerLayout/index.tsx
@@ -1,0 +1,1 @@
+export * from './PlayerLayout';

--- a/packages/web/src/components/views/Home/Home.tsx
+++ b/packages/web/src/components/views/Home/Home.tsx
@@ -1,41 +1,18 @@
-import React, { useCallback, useState } from 'react';
-
 import { DividingHeader } from '~/components/atoms/DividingHeader';
-import { Controls } from '~/components/molecules/Controls/Controls';
 import { Library } from '~/components/molecules/Library';
-import { Nav } from '~/components/molecules/Nav';
-import { SearchHeader } from '~/components/molecules/SearchHeader';
 import { TrackCount } from '~/components/molecules/TrackCount';
-import { PageContainer } from '~/components/templates/PageContainer';
-import { PlayerProvider } from '~/context/PlayerContext';
 import { usePollingLibrary } from '~/hooks/usePollingLibrary';
 
 export function Home() {
-  const [navOpen, setNavOpen] = useState(false);
-  const toggleNavOpen = useCallback(() => setNavOpen((o) => !o), [setNavOpen]);
   const { loading } = usePollingLibrary();
 
   return (
-    <PlayerProvider>
-      <PageContainer>
-        <Nav open={navOpen} toggleNav={toggleNavOpen} />
-        {/* Main column */}
-        <div className="flex flex-col w-0 flex-1 overflow-hidden">
-          <SearchHeader onToggleNavigationOpen={toggleNavOpen} />
-          <main
-            className="flex-1 @container flex-col flex-nowrap relative z-0 overflow-hidden focus:outline-hidden"
-            tabIndex={0}
-            id="library-container"
-          >
-            {/* Page title & actions */}
-            <DividingHeader>Library</DividingHeader>
-            <TrackCount loading={loading} />
-            {/* Library table */}
-            <Library />
-            <Controls />
-          </main>
-        </div>
-      </PageContainer>
-    </PlayerProvider>
+    <>
+      {/* Page title & actions */}
+      <DividingHeader>Library</DividingHeader>
+      <TrackCount loading={loading} />
+      {/* Library table */}
+      <Library />
+    </>
   );
 }

--- a/packages/web/src/components/views/Recent/Recent.tsx
+++ b/packages/web/src/components/views/Recent/Recent.tsx
@@ -1,0 +1,33 @@
+import { bindActionCreators, EntityId } from '@reduxjs/toolkit';
+
+import { FullHeightContainer } from '~/components/atoms/FullHeightContainer/FullHeightContainer';
+import { TrackList } from '~/components/molecules/TrackList';
+import { useAppDispatch, useAppSelector } from '~/hooks';
+import { useCurrentTrack } from '~/hooks/useCurrentTrack';
+import { librarySelectors } from '~/store/slices/library/selectors';
+import { playTrack } from '~/store/slices/player/player';
+
+export const Recent = () => {
+  const historyTrackIds = useAppSelector(librarySelectors.selectLibraryHistory);
+  const currentTrack = useCurrentTrack();
+  const dispatch = useAppDispatch();
+  const play = bindActionCreators(playTrack, dispatch);
+
+  const handlePlayTrackFromHistory = ({ trackId }: { trackId: EntityId }) => {
+    play({ trackId, requeue: true, context: 'history', addHistory: false });
+  };
+
+  return (
+    <FullHeightContainer>
+      <TrackList
+        context="history"
+        trackIDs={historyTrackIds}
+        onPlayTrackId={({ trackId }) =>
+          trackId != null && handlePlayTrackFromHistory({ trackId })
+        }
+        onFilterLibrary={() => undefined}
+        currentTrack={currentTrack}
+      />
+    </FullHeightContainer>
+  );
+};

--- a/packages/web/src/components/views/Recent/index.tsx
+++ b/packages/web/src/components/views/Recent/index.tsx
@@ -1,0 +1,1 @@
+export * from './Recent';


### PR DESCRIPTION
The goal of this PR is to create a new "Recent" route, that displays recently played tracks. It should refactor the Home Library component such that it is no longer responsible for measuring the page, and laying out the controls, and instead should just render the track list and search capabilities. The page measurement and controls placement should instead be handled by a route layout, that applies this logic to all routes in the application `/` and `/recent`.